### PR TITLE
Add auto knowledge update script

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,6 +264,7 @@ Knowledge refers to the user-provided information and data that agents can lever
   - Supported formats: `.txt`, `.pdf`, `.csv`, `.html`, `.json`, `.md`
   - Automatically imported and indexed
   - Expandable format support
+  - Alternatively, drop files into `/knowledge/inbox` and execute `python update_knowledge.py` to import them
 
 - **Knowledge Base**: 
   - Can include PDFs, databases, books, documentation

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,6 +37,7 @@ Located beneath the chat input box, Agent Zero provides a set of action buttons 
   - Files are stored in `\knowledge\custom\main`
   - Success message confirms successful import
   - See [knowledge](architecture.md#knowledge) for more details
+* **Auto Knowledge Folder:** Drop files into `\knowledge\inbox` and run `python update_knowledge.py` (or the "wissen aktualisieren" command) to load them into the knowledge base
 
 ### File Browser: Manage files in the Agent Zero environment
   - Upload new files and folders

--- a/update_knowledge.py
+++ b/update_knowledge.py
@@ -1,0 +1,36 @@
+import os
+import shutil
+import asyncio
+
+from initialize import initialize
+from agent import AgentContext
+from python.helpers import files, memory
+
+
+async def update_knowledge():
+    config = initialize()
+    context = AgentContext(config)
+
+    inbox_dir = files.get_abs_path("knowledge", "inbox")
+    target_dir = os.path.join(memory.get_custom_knowledge_subdir_abs(context.agent0), "main")
+
+    os.makedirs(inbox_dir, exist_ok=True)
+    os.makedirs(target_dir, exist_ok=True)
+
+    moved = []
+    for fname in os.listdir(inbox_dir):
+        src = os.path.join(inbox_dir, fname)
+        dest = os.path.join(target_dir, fname)
+        if os.path.isfile(src):
+            shutil.move(src, dest)
+            moved.append(fname)
+
+    if moved:
+        await memory.Memory.reload(context.agent0)
+        print(f"Imported {len(moved)} file(s) into the knowledge base: {', '.join(moved)}")
+    else:
+        print("No new files found in inbox directory")
+
+
+if __name__ == "__main__":
+    asyncio.run(update_knowledge())


### PR DESCRIPTION
## Summary
- add `knowledge/inbox` directory
- provide `update_knowledge.py` script for importing new files
- document the auto-import folder in architecture and usage docs

## Testing
- `pytest -q`
- `python -m py_compile update_knowledge.py`


------
https://chatgpt.com/codex/tasks/task_e_68413ea15134833193be51a8720c0d53